### PR TITLE
Add support to report multiple errors

### DIFF
--- a/src/fail.js
+++ b/src/fail.js
@@ -2,8 +2,8 @@
 
 const { toMultipleTestResults } = require("./toMultipleTestResults");
 
-module.exports.fail = ({ start, end, failures }) =>
-  toMultipleTestResults({
+module.exports.fail = ({ start, end, failures }) => {
+  return toMultipleTestResults({
     stats: {
       failures: failures.length,
       pending: 0,
@@ -16,3 +16,4 @@ module.exports.fail = ({ start, end, failures }) =>
     jestTestPath: failures[0].path,
     skipped: false,
   });
+}

--- a/src/fail.js
+++ b/src/fail.js
@@ -1,0 +1,18 @@
+// @ts-check
+
+const { toMultipleTestResults } = require("./toMultipleTestResults");
+
+module.exports.fail = ({ start, end, failures }) =>
+  toMultipleTestResults({
+    stats: {
+      failures: failures.length,
+      pending: 0,
+      passes: 0,
+      todo: 0,
+      start,
+      end,
+    },
+    tests: failures,
+    jestTestPath: failures[0].path,
+    skipped: false,
+  });

--- a/src/run.js
+++ b/src/run.js
@@ -17,7 +17,7 @@ module.exports = async ({ testPath }) => {
     const failures = diagnose.map((test) => ({
       path: test.fileName,
       errorMessage: test.message,
-      title: test.severity + testFile,
+      title: "In " + testFile + ": " + test.message,
     }));
     return fail({
       start,

--- a/src/run.js
+++ b/src/run.js
@@ -1,32 +1,37 @@
-const tsd = require('tsd');
-const { pass, fail } = require('create-jest-runner');
+// @ts-check
+
+const tsd = require("tsd");
+const { pass } = require("create-jest-runner");
+const { fail } = require("./fail");
 
 module.exports = async ({ testPath }) => {
   // Convert absolute path to relative path
-  const testFile = testPath.replace(process.cwd(), '');
+  const testFile = testPath.replace(process.cwd(), "");
   const start = +new Date();
-  const diagnose = await tsd({
+  const diagnose = await tsd.default({
     cwd: process.cwd(),
-    testFiles: [ testFile ]
+    testFiles: [testFile],
   });
 
-  // Currently only reports a single error.
   if (diagnose.length > 0) {
+    const failures = diagnose.map((test) => ({
+      path: test.fileName,
+      errorMessage: test.message,
+      title: test.severity + testFile,
+    }));
     return fail({
       start,
       end: +new Date(),
-      test: {
-        path: diagnose[0].fileName, 
-        errorMessage: diagnose[0].message, 
-        title: diagnose[0].severity + ' ' + testFile
-      }
+      failures: failures,
     });
   }
 
+  // @TODO Include the number of successful tests
   return pass({
-    start, end: +new Date(), 
+    start,
+    end: +new Date(),
     test: {
-      path: testPath
-    } 
+      path: testPath,
+    },
   });
 };

--- a/src/run.js
+++ b/src/run.js
@@ -17,12 +17,13 @@ module.exports = async ({ testPath }) => {
     const failures = diagnose.map((test) => ({
       path: test.fileName,
       errorMessage: test.message,
-      title: "In " + testFile + ": " + test.message,
+      title: `${testFile}:${test.line}:${test.column} - ${test.severity} - ${test.message}`
     }));
+
     return fail({
       start,
       end: +new Date(),
-      failures: failures,
+      failures
     });
   }
 

--- a/src/toMultipleTestResults.js
+++ b/src/toMultipleTestResults.js
@@ -1,0 +1,41 @@
+module.exports.toMultipleTestResults = ({
+  stats,
+  skipped,
+  tests,
+  jestTestPath,
+}) => {
+  return {
+    console: null,
+    numFailingTests: stats.failures,
+    numPassingTests: stats.passes,
+    numPendingTests: stats.pending,
+    numTodoTests: stats.todo,
+    perfStats: {
+      end: new Date(stats.end).getTime(),
+      start: new Date(stats.start).getTime(),
+    },
+    skipped,
+    snapshot: {
+      added: 0,
+      fileDeleted: false,
+      matched: 0,
+      unchecked: 0,
+      unmatched: 0,
+      updated: 0,
+    },
+    sourceMaps: {},
+    testExecError: null,
+    testFilePath: jestTestPath,
+    testResults: tests.map((test) => {
+      return {
+        ancestorTitles: [],
+        duration: test.duration,
+        failureMessages: [test.errorMessage],
+        fullName: test.testPath,
+        numPassingAsserts: test.errorMessage ? 1 : 0,
+        status: test.errorMessage ? "failed" : "passed",
+        title: test.title || "",
+      };
+    }),
+  };
+};


### PR DESCRIPTION
Fixes #1 

Merge only after https://github.com/MLH-Fellowship/jest-runner-tsd/issues/4 is fixed.

The `fail` function has been updated to report of multiple errors in `fail.js` Correspondingly, the runner has been updated to call this custom implementation of `fail` in `run.js`. Finally, `toMultipleTestResults` has been derived from `toTestResults` to support this custom implementation of `fail` and some of the optional parameters in `toTestResults` removed.

Below is the screenshot demonstrating multiple error reporting 
![image](https://user-images.githubusercontent.com/32371951/86920438-6df78c00-c147-11ea-8b27-18334ca87d7c.png)


TODO: The `pass` function in `run.js` has to be updated to report the number of tests passed. This can be done only after the required changes are made in the [tsd repo](https://github.com/MLH-Fellowship/tsd)
