### PR TITLE
Allow specifying type def file path in test file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "dependencies": {
     "create-jest-runner": "^0.6.0",
+    "jest-docblock": "^26.0.0",
     "tsd": "^0.11.0"
   }
 }

--- a/src/run.js
+++ b/src/run.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 const tsd = require('tsd');
+const { join } = require('path');
 const { pass } = require('./pass');
 const { fail } = require('./fail');
 const { readFileSync } = require('fs');
@@ -14,18 +15,22 @@ const findTypingsFile = testPath => {
   const parsedDocblocks = parse(fileContents);
   const typingsFile = String(parsedDocblocks.type);
 
-  return { typingsFile };
+  return typingsFile;
 }
 
 module.exports = async ({ testPath }) => {
   // Convert absolute path to relative path
   const testFile = testPath.replace(process.cwd(), '');
   const start = +new Date();
-  const typingsFile = findTypingsFile(testPath);
+  const typingsFileRelativePath = findTypingsFile(testPath);
+
+  // Remove filename from the path and join it with typingsFile relative path
+  const typingsFile = join(testFile.substring(0, testFile.lastIndexOf('/')), typingsFileRelativePath);
+
   const extendedDiagnostics = await tsd.default({
     cwd: process.cwd(),
     testFiles: [testFile],
-    ...typingsFile,
+    typingsFile,
   });
 
   const numTests = extendedDiagnostics.numTests;

--- a/src/run.js
+++ b/src/run.js
@@ -3,11 +3,26 @@
 const tsd = require('tsd');
 const { pass } = require('./pass');
 const { fail } = require('./fail');
+const { readFileSync } = require('fs');
+const { parse } = require('jest-docblock');
+
+/**
+ * @param {string} testPath 
+ * @returns {string}
+ */
+const findTypingsFile = testPath => {
+  const fileContents = readFileSync(testPath).toString();
+  const parsedDocblocks = parse(fileContents);
+  const typingsFile = String(parsedDocblocks.type);
+
+  return typingsFile;
+}
 
 module.exports = async ({ testPath }) => {
   // Convert absolute path to relative path
   const testFile = testPath.replace(process.cwd(), '');
   const start = +new Date();
+  const typingsFile = findTypingsFile(testPath);
   const extendedDiagnostics = await tsd.default({
     cwd: process.cwd(),
     testFiles: [testFile],

--- a/src/run.js
+++ b/src/run.js
@@ -7,15 +7,14 @@ const { readFileSync } = require('fs');
 const { parse } = require('jest-docblock');
 
 /**
- * @param {string} testPath 
- * @returns {string}
+ * @param {string} testPath
  */
 const findTypingsFile = testPath => {
   const fileContents = readFileSync(testPath).toString();
   const parsedDocblocks = parse(fileContents);
   const typingsFile = String(parsedDocblocks.type);
 
-  return typingsFile;
+  return { typingsFile };
 }
 
 module.exports = async ({ testPath }) => {
@@ -26,6 +25,7 @@ module.exports = async ({ testPath }) => {
   const extendedDiagnostics = await tsd.default({
     cwd: process.cwd(),
     testFiles: [testFile],
+    ...typingsFile,
   });
 
   const numTests = extendedDiagnostics.numTests;

--- a/yarn.lock
+++ b/yarn.lock
@@ -401,6 +401,11 @@ define-property@^2.0.2:
     is-descriptor "^1.0.2"
     isobject "^3.0.1"
 
+detect-newline@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
+  integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
 dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -902,6 +907,13 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
+jest-docblock@^26.0.0:
+  version "26.0.0"
+  resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
+  integrity sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
+  dependencies:
+    detect-newline "^3.0.0"
 
 jest-worker@^25.1.0:
   version "25.5.0"


### PR DESCRIPTION
This PR allows developers to pass the path to type definition files via the test file itself using `docblocks`.

This is how it's done
```ts
import {expectType} from 'tsd';

/**
 * This tells the custom runner where to look for the type def file.
 * Runner will then resolve the path and pass it to TSD
 *
 * @type ../types.ts
 */

expectType<string>(concat('foo', 'bar'));
expectType<string>(concat(1, 2));
```
